### PR TITLE
feat: Update Jumanji version and the env specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ key = jax.random.PRNGKey(0)
 state, timestep = jax.jit(env.reset)(key)
 
 # Interact with the (jit-able) environment
-action = env.action_spec().generate_value()          # Action selection (dummy value here)
+action = env.action_spec.generate_value()          # Action selection (dummy value here)
 state, timestep = jax.jit(env.step)(state, action)   # Take a step and observe the next state and time step
 ```
 

--- a/matrax/__init__.py
+++ b/matrax/__init__.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from jumanji.registration import make, register
-from jumanji.version import __version__
 
 from matrax.env import MatrixGame
 from matrax.games import climbing_game, conflict_games, no_conflict_games, penalty_games
 from matrax.types import Observation, State
+from matrax.version import __version__
 
 """Environment Registration"""
 

--- a/matrax/env_test.py
+++ b/matrax/env_test.py
@@ -43,8 +43,8 @@ def matrix_game_env_with_state() -> MatrixGame:
 
 def test_matrix_game__specs(matrix_game_env: MatrixGame) -> None:
     """Validate environment specs conform to the expected shapes and values"""
-    action_spec = matrix_game_env.action_spec()
-    observation_spec = matrix_game_env.observation_spec()
+    action_spec = matrix_game_env.action_spec
+    observation_spec = matrix_game_env.observation_spec
 
     assert observation_spec.agent_obs.shape == (2, 2)  # type: ignore
     assert action_spec.num_values.shape[0] == matrix_game_env.num_agents

--- a/matrax/version.py
+++ b/matrax/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-jumanji==0.3.1
+jumanji==1.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-jumanji==1.0.1
+jumanji


### PR DESCRIPTION
## What?
Update the Jumanji version and make all the necessary changes for the specs to respect what Jumanji's default `Environment` class does.
## Why?
This solves the conflict of dependencies when updating Jumanji in the Mava repository.